### PR TITLE
Update regex parser to be more lenient

### DIFF
--- a/lib/debug-env.js
+++ b/lib/debug-env.js
@@ -24,7 +24,8 @@ exports.enabled = function(name) {
 };
 
 exports.add = function(pattern, enabled) {
-  pattern = pattern.replace('*', '.*?');
+  pattern = pattern.replace(/\*/g, '.*?');
+
   if (enabled === undefined) {
     if (pattern[0] === '-') {
       enabled = false;

--- a/test/lugg-tests.js
+++ b/test/lugg-tests.js
@@ -86,5 +86,8 @@ describe('debug', function() {
     assert.equal(lugg('foo:disabled').level(), bunyan.INFO, 'disabled');
     lugg.debug('-app:foo:minus');
     assert.equal(lugg('foo:minus').level(), bunyan.INFO, 'minus');
+    lugg.debug('*app*');
+    assert.equal(lugg('bar').level(), bunyan.DEBUG, 'debug bar');
+    assert.equal(lugg('biz').level(), bunyan.DEBUG, 'debug biz');
   });
 });


### PR DESCRIPTION
The parser will now match _keyword_ to loggers with a namespace such as
`keyword:foo`, `keyword:bar`. This is exactly the same behaviour as the `debug` module.

Updated `exports` to `module.exports` as it is the recommended usage form. 
