### PR TITLE
Disable output when debug is disabled

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,8 @@ function createLogger(name, options, simple) {
   }
 
   options = defaults(options, {
-    module: name
+    module: name,
+    level: bunyan.FATAL + 1
   });
 
   if (isDebugEnabled(fmt('%s:%s', rootName, name))) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "test-runner": "mocha -w"
   },
   "dependencies": {
-    "bunyan": "^1.0.1",
+    "bunyan": "^1.2.3",
     "defaults": "^1.0.0",
     "mocha": "^2.0.1"
   },

--- a/test/lugg-tests.js
+++ b/test/lugg-tests.js
@@ -1,31 +1,45 @@
-var lugg = require('..'),
+
+/**
+ * Module dependencies.
+ */
+
+var bunyan = require('bunyan'),
+    lugg = require('..'),
     debug = require('../lib/debug-env.js'),
     assert = require('assert');
 
 describe('lugg.init()', function() {
   it('with no arguments', function() {
     lugg.init();
+
     var log = lugg();
+
     assert.equal(log.fields.name, 'app');
   });
+
   it('with arguments', function() {
     lugg.init({
       name: 'theName',
       stream: process.stderr
     });
+
     var log = lugg();
+
     assert.equal(log.fields.name, 'theName');
     assert(log.streams[0].stream == process.stderr);
-    assert(log.streams[0].level == 30);
+    assert(log.streams[0].level == bunyan.INFO);
   });
+
   it('can specify the log level', function() {
     lugg.init({
       name: 'name',
       stream: process.stderr,
       level: 'error'
     });
+
     var log = lugg();
-    assert.equal(log.level(), 50);
+
+    assert.equal(log.level(), bunyan.ERROR);
   });
 });
 
@@ -33,57 +47,80 @@ describe('lugg()', function() {
   beforeEach(function() {
     lugg.init();
   });
+
   it('returns createLogger on init', function() {
     var log = lugg.init()('test');
+
     assert.equal(log.fields.module, 'test');
-  })
+  });
+
   it('creates loggers', function() {
     var log = lugg('test');
+
     assert.equal(log.fields.name, 'app');
     assert.equal(log.fields.module, 'test');
-  })
+  });
+
   it('accepts options', function() {
     var log = lugg('test', {
       foo: 'bar'
     });
+
     assert.equal(log.fields.module, 'test');
     assert.equal(log.fields.foo, 'bar');
   });
+
   it('can set log level', function() {
     var log = lugg('test');
+
     log.level('error');
-    assert.equal(log.level(), 50);
+
+    assert.equal(log.level(), bunyan.ERROR);
   });
 });
 
 describe('debug', function() {
   beforeEach(function() {
     debug.parse('');
+
     lugg.init();
   });
+
   it('based on environment', function() {
     process.env.DEBUG = 'app:test';
+
     debug.update();
-    assert.equal(lugg('test').level(), 20, 'app:test is debug');
-    assert.equal(lugg('foo').level(), 30, 'app:foo is not debug');
+
+    assert.equal(lugg('test').level(), bunyan.DEBUG, 'app:test is debug');
+    assert.equal(lugg('foo').level(), bunyan.FATAL + 1, 'app:foo is disabled');
   });
+
   it('app:*', function() {
     debug.parse('app:*');
-    assert.equal(lugg('test').level(), 20, 'app:test is debug');
-    assert.equal(lugg('foo').level(), 20, 'app:foo is debug');
+
+    assert.equal(lugg('test').level(), bunyan.DEBUG, 'app:test is debug');
+    assert.equal(lugg('foo').level(), bunyan.DEBUG, 'app:foo is debug');
   });
+
   it('app:*,-app:foo', function() {
     debug.parse('app:*,-app:foo');
-    assert.equal(lugg('test').level(), 20);
-    assert.equal(lugg('foo').level(), 30);
+
+    assert.equal(lugg('test').level(), bunyan.DEBUG);
+    assert.equal(lugg('foo').level(), bunyan.FATAL + 1);
   });
+
   it('using debug function', function() {
     lugg.debug('app:foo');
-    assert.equal(lugg('not').level(), 30, 'not');
-    assert.equal(lugg('foo').level(), 20, 'debug foo');
+
+    assert.equal(lugg('not').level(), bunyan.FATAL + 1, 'not');
+    assert.equal(lugg('foo').level(), bunyan.DEBUG, 'debug foo');
+
     lugg.debug('app:foo:disabled', false);
-    assert.equal(lugg('foo:disabled').level(), 30, 'disabled');
+
+    assert.equal(lugg('foo:disabled').level(), bunyan.FATAL + 1, 'disabled');
+
     lugg.debug('-app:foo:minus');
-    assert.equal(lugg('foo:minus').level(), 30, 'minus');
+
+    assert.equal(lugg('foo:minus').level(), bunyan.FATAL + 1, 'minus');
   });
 });


### PR DESCRIPTION
After a discussion with my teammate @fixe, we came to the conclusion that following tj's principles for the `debug` module it is unexpected to see `lugg` outputting logging from bunyan even when the env var `DEBUG` is not set. Since `v1.2.2`, bunyan also supports disabling logging by passing a higher level than `FATAL` to its options, so we think this is the best default approach for `lugg`.

This PR means that there is a breaking change and so the major version would have to be bumped if it is accepted. At the same time, the code readability has been improved, although that is a personal view on the matter.
